### PR TITLE
State management

### DIFF
--- a/java/claim/src/main/java/io/opensaber/claim/entity/Claim.java
+++ b/java/claim/src/main/java/io/opensaber/claim/entity/Claim.java
@@ -154,11 +154,9 @@ public class Claim {
 
     public static Claim fromDTO(ClaimDTO claimDTO) {
         Claim claim = new Claim();
-        claim.setPropertyId(claimDTO.getPropertyId());
-        claim.setProperty(claimDTO.getProperty());
+        claim.setProperty(claimDTO.getPropertyURI());
         claim.setEntity(claimDTO.getEntity());
         claim.setEntityId(claimDTO.getEntityId());
-        claim.setPropertyId(claimDTO.getPropertyId());
         claim.setConditions(claimDTO.getConditions());
         claim.setAttestorEntity(claimDTO.getAttestorEntity());
         claim.setStatus(ClaimStatus.OPEN.name());

--- a/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/JSONUtil.java
+++ b/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/JSONUtil.java
@@ -435,4 +435,14 @@ public class JSONUtil {
 
 		});
 	}
+
+	public static void removeNodes(JsonNode node, List<String> backList) {
+		if (node.isArray()) {
+			for (JsonNode child: node) {
+				removeNodes(child, backList);
+			}
+		} else if (node.isObject()){
+			removeNodes((ObjectNode) node, backList);
+		}
+	}
 }

--- a/java/pojos/src/main/java/io/opensaber/pojos/dto/ClaimDTO.java
+++ b/java/pojos/src/main/java/io/opensaber/pojos/dto/ClaimDTO.java
@@ -4,8 +4,7 @@ package io.opensaber.pojos.dto;
 public class ClaimDTO {
     private String entity;
     private String entityId;
-    private String property;
-    private String propertyId;
+    private String propertyURI;
     private String notes;
     private String status;
     private String conditions;
@@ -26,20 +25,12 @@ public class ClaimDTO {
         this.entityId = entityId;
     }
 
-    public String getProperty() {
-        return property;
+    public String getPropertyURI() {
+        return propertyURI;
     }
 
-    public void setProperty(String property) {
-        this.property = property;
-    }
-
-    public String getPropertyId() {
-        return propertyId;
-    }
-
-    public void setPropertyId(String propertyId) {
-        this.propertyId = propertyId;
+    public void setPropertyURI(String propertyURI) {
+        this.propertyURI = propertyURI;
     }
 
     public String getNotes() {

--- a/java/registry/pom.xml
+++ b/java/registry/pom.xml
@@ -54,6 +54,12 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.20</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/java/registry/src/main/java/io/opensaber/registry/helper/EntityStateHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/helper/EntityStateHelper.java
@@ -1,0 +1,160 @@
+package io.opensaber.registry.helper;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.opensaber.pojos.attestation.AttestationPolicy;
+import io.opensaber.pojos.dto.ClaimDTO;
+import io.opensaber.registry.middleware.service.ConditionResolverService;
+import io.opensaber.registry.model.attestation.AttestationPath;
+import io.opensaber.registry.model.attestation.EntityPropertyURI;
+import io.opensaber.registry.model.state.Action;
+import io.opensaber.registry.model.state.StateContext;
+import io.opensaber.registry.service.RuleEngineService;
+import io.opensaber.registry.util.ClaimRequestClient;
+import io.opensaber.registry.util.DefinitionsManager;
+import org.apache.commons.math3.util.Pair;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.*;
+
+@Component
+public class EntityStateHelper {
+
+    @Value("${database.uuidPropertyName}")
+    private String uuidPropertyName;
+
+    @Autowired
+    private DefinitionsManager definitionsManager;
+
+    @Autowired
+    private RuleEngineService ruleEngineService;
+
+    @Autowired
+    private ConditionResolverService conditionResolverService;
+
+    @Autowired
+    private ClaimRequestClient claimRequestClient;
+
+    public void changeStateAfterUpdate(JsonNode existing, JsonNode updated) {
+        String entityName = updated.fields().next().getKey();
+        JsonNode modified = updated.get(entityName);
+
+        List<String> ignoredProperties = definitionsManager.getDefinition(entityName).getOsSchemaConfiguration().getSystemFields();
+        List<AttestationPolicy> attestationPolicies = definitionsManager.getAttestationPolicy(entityName);
+
+        for (AttestationPolicy policy: attestationPolicies) {
+            Set<EntityPropertyURI> targetPathPointers = new AttestationPath(policy.getProperty())
+                    .getEntityPropertyURIs(modified, uuidPropertyName);
+
+            for(EntityPropertyURI tp: targetPathPointers) {
+                Optional<EntityPropertyURI> entityPropertyURI = EntityPropertyURI.fromEntityAndPropertyURI(
+                        existing.get(entityName), tp.getPropertyURI(), uuidPropertyName
+                );
+                JsonNode existingSubNode = JsonNodeFactory.instance.objectNode();
+                if (entityPropertyURI.isPresent()) {
+                    existingSubNode = existing.get(entityName).at(entityPropertyURI.get().getJsonPointer());
+                }
+
+                Pair<ObjectNode, JsonPointer> metadataNodePointer = getTargetMetadataNodeInfo(modified, tp.getJsonPointer());
+                StateContext stateContext = StateContext.builder()
+                        .entityName(entityName)
+                        .existing(existingSubNode)
+                        .updated(modified.at(tp.getJsonPointer()))
+                        .ignoredFields(ignoredProperties)
+                        .attestationPolicy(policy)
+                        .metadataNode(metadataNodePointer.getFirst())
+                        .pointerFromMetadataNode(metadataNodePointer.getSecond())
+                        .build();
+                ruleEngineService.doTransition(stateContext);
+            }
+        }
+    }
+
+    public JsonNode sendForAttestation(JsonNode entityNode, String propertyURL) throws Exception {
+       return manageState(entityNode, propertyURL, Action.RAISE_CLAIM, JsonNodeFactory.instance.objectNode());
+    }
+
+    public JsonNode attestClaim(JsonNode entityNode, String uuidPath) throws Exception {
+        return manageState(entityNode, uuidPath, Action.GRANT_CLAIM, JsonNodeFactory.instance.objectNode());
+    }
+
+    private JsonNode manageState(JsonNode root, String propertyURL, Action action, @NotEmpty ObjectNode metaData) throws Exception {
+        String entityName = root.fields().next().getKey();
+        JsonNode entityNode = root.get(entityName);
+        Optional<AttestationPolicy> matchingPolicy = getMatchingAttestationPolicy(entityName, entityNode, propertyURL);
+        if (!matchingPolicy.isPresent()) throw new Exception(propertyURL + " did not match any attestation policy");
+        AttestationPolicy policy = matchingPolicy.get();
+
+        Optional<EntityPropertyURI> entityPropertyURI = EntityPropertyURI.fromEntityAndPropertyURI(entityNode, propertyURL, uuidPropertyName);
+        if (!entityPropertyURI.isPresent()) {
+            throw new Exception("Invalid Property Identifier : "+ propertyURL);
+        }
+
+        Pair<ObjectNode, JsonPointer> metadataNodePointer = getTargetMetadataNodeInfo(entityNode, entityPropertyURI.get().getJsonPointer());
+
+        if (action.equals(Action.RAISE_CLAIM)) {
+            metaData.set(
+                    "claimId",
+                    JsonNodeFactory.instance.textNode(raiseClaim(entityName, propertyURL, metadataNodePointer.getFirst(), policy))
+            );
+        }
+
+        StateContext stateContext = StateContext.builder()
+                .entityName(entityName)
+                .existing(entityNode.at(entityPropertyURI.get().getJsonPointer()))
+                .action(action)
+                .ignoredFields(definitionsManager.getDefinition(entityName).getOsSchemaConfiguration().getSystemFields())
+                .attestationPolicy(policy)
+                .metaData(metaData)
+                .metadataNode(metadataNodePointer.getFirst())
+                .pointerFromMetadataNode(metadataNodePointer.getSecond())
+                .build();
+        ruleEngineService.doTransition(stateContext);
+        return root;
+    }
+
+    public Optional<AttestationPolicy> getMatchingAttestationPolicy(String entityName, JsonNode rootNode, String uuidPath) {
+        int uuidPathDepth = uuidPath.split("/").length;
+        String matchingUUIDPath = "/" + uuidPath;
+        for (AttestationPolicy policy: definitionsManager.getAttestationPolicy(entityName)) {
+            if (policy.getProperty().split("/").length != uuidPathDepth) continue;
+           if (new AttestationPath(policy.getProperty())
+                    .getEntityPropertyURIs(rootNode, uuidPropertyName)
+                    .stream().anyMatch(p -> p.getPropertyURI().equals(matchingUUIDPath))) {
+               return Optional.of(policy);
+           }
+        }
+        return Optional.empty();
+    }
+
+    public String raiseClaim(String entityName, String uuidPath, JsonNode node, AttestationPolicy attestationPolicy) {
+        String resolvedConditions =  conditionResolverService.resolve(node, "REQUESTER", attestationPolicy.getConditions(), Collections.emptyList());
+        ClaimDTO claimDTO = new ClaimDTO();
+        claimDTO.setEntity(entityName);
+        claimDTO.setEntityId(node.get(uuidPropertyName).asText());
+        claimDTO.setPropertyURI(uuidPath);
+        claimDTO.setConditions(resolvedConditions);
+        claimDTO.setAttestorEntity(attestationPolicy.getAttestorEntity());
+        return claimRequestClient.riseClaimRequest(claimDTO).get("id").toString();
+    }
+
+    private Pair<ObjectNode, JsonPointer> getTargetMetadataNodeInfo(JsonNode rootNode, JsonPointer targetPointer) {
+        JsonNode metadataNode = rootNode.at(targetPointer);
+        LinkedList<JsonPointer> traversed = new LinkedList<>();
+        while (!metadataNode.isObject()) {
+            traversed.addFirst(targetPointer.last());
+            metadataNode = rootNode.at(targetPointer.head());
+            targetPointer = targetPointer.head();
+        }
+        return new Pair<>(
+                (ObjectNode) metadataNode,
+                traversed.stream().reduce(JsonPointer.compile(""), JsonPointer::append)
+        );
+    }
+
+}

--- a/java/registry/src/main/java/io/opensaber/registry/helper/EntityStateHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/helper/EntityStateHelper.java
@@ -46,6 +46,7 @@ public class EntityStateHelper {
 
         List<String> ignoredProperties = definitionsManager.getDefinition(entityName).getOsSchemaConfiguration().getSystemFields();
         List<AttestationPolicy> attestationPolicies = definitionsManager.getAttestationPolicy(entityName);
+        List<StateContext> allContexts = new ArrayList<>();
 
         for (AttestationPolicy policy: attestationPolicies) {
             Set<EntityPropertyURI> targetPathPointers = new AttestationPath(policy.getProperty())
@@ -70,9 +71,10 @@ public class EntityStateHelper {
                         .metadataNode(metadataNodePointer.getFirst())
                         .pointerFromMetadataNode(metadataNodePointer.getSecond())
                         .build();
-                ruleEngineService.doTransition(stateContext);
+                allContexts.add(stateContext);
             }
         }
+        ruleEngineService.doTransition(allContexts);
     }
 
     public JsonNode sendForAttestation(JsonNode entityNode, String propertyURL) throws Exception {

--- a/java/registry/src/main/java/io/opensaber/registry/model/attestation/AttestationPath.java
+++ b/java/registry/src/main/java/io/opensaber/registry/model/attestation/AttestationPath.java
@@ -1,0 +1,81 @@
+package io.opensaber.registry.model.attestation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.util.*;
+
+public class AttestationPath {
+    private static final String ARRAY_STEP = "[]" ;
+    private static final String SEP = "/";
+    private final String path;
+    private transient List<String> steps;
+
+    public AttestationPath(String path) {
+        this.path = path;
+    }
+
+    private void setSteps() {
+        if (this.steps != null) {
+            return;
+        }
+
+        List<String> steps = new ArrayList<>();
+        StringBuilder curr = new StringBuilder();
+        for (String step: path.split(SEP)) {
+            if (!step.equals(ARRAY_STEP)) {
+                curr.append(SEP).append(step);
+            } else {
+                if (curr.length() > 0) steps.add(curr.toString());
+                steps.add(step);
+                curr.setLength(0);
+            }
+        }
+        if (curr.length() > 0) steps.add(curr.toString());
+        this.steps = Collections.unmodifiableList(steps);
+    }
+
+    public String getPath() {
+        return this.path;
+    }
+
+    public Set<EntityPropertyURI> getEntityPropertyURIs(JsonNode node, String uuidPropertyName) {
+        Queue<EntityPropertyURI> currPaths = new LinkedList<EntityPropertyURI>(){{
+            add(new EntityPropertyURI("", ""));
+        }};
+        if (steps == null) setSteps();
+        for (String step: steps) {
+            int currCount = currPaths.size();
+            for (int i = 0; i < currCount; i++) {
+                EntityPropertyURI currPath = currPaths.remove();
+                if (!step.equals(ARRAY_STEP)) {
+                    currPaths.add(EntityPropertyURI.merge(currPath, step, step));
+                    continue;
+                }
+                JsonNode currNode = node.at(currPath.getJsonPointer());
+                if (currNode == null || currNode.isMissingNode()) {
+                    continue;
+                }
+                ArrayNode arrayNode = (ArrayNode) currNode;
+                for (int j = 0; j < arrayNode.size(); j++) {
+                    if (arrayNode.get(j).isObject()) {
+                        JsonNode uuidNode = arrayNode.get(j).get(uuidPropertyName);
+                        String uuidPointer = SEP;
+                        if (uuidNode == null || uuidNode.isMissingNode()) {
+                            uuidPointer = uuidPointer + "NO_UUID";
+                        } else {
+                            uuidPointer = uuidPointer + uuidNode.asText();
+                        }
+                        currPaths.add(EntityPropertyURI.merge(currPath,
+                                uuidPointer,
+                                SEP + j
+                        ));
+                    } else {
+                        currPaths.add(EntityPropertyURI.merge(currPath, SEP + j, SEP + j));
+                    }
+                }
+            }
+        }
+        return new HashSet<>(currPaths);
+    }
+}

--- a/java/registry/src/main/java/io/opensaber/registry/model/attestation/EntityPropertyURI.java
+++ b/java/registry/src/main/java/io/opensaber/registry/model/attestation/EntityPropertyURI.java
@@ -1,6 +1,10 @@
 package io.opensaber.registry.model.attestation;
 
 import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.util.Optional;
 
 public class EntityPropertyURI {
     String propertyURI;
@@ -26,5 +30,39 @@ public class EntityPropertyURI {
         merged.propertyURI = m1.propertyURI + uuidPath;
         merged.jsonPointer = JsonPointer.compile(m1.jsonPointer.toString() + jsonPath);
         return merged;
+    }
+
+    public static Optional<EntityPropertyURI> fromEntityAndPropertyURI(JsonNode node, String propertyURI, String uuidPropertyName) {
+        String[] steps = (propertyURI.startsWith("/") ? propertyURI.substring(1) : propertyURI).split("/");
+        JsonNode curr = node;
+        for (int i = 0; i < steps.length; i++) {
+            if (curr == null || curr.isMissingNode()) {
+                return Optional.empty();
+            }
+            if (!curr.isArray()) {
+                curr = curr.get(steps[i]);
+                continue;
+            }
+            int index = -1;
+            try {
+                index = Integer.parseInt(steps[i]);
+            } catch (NumberFormatException nfe) {
+                ArrayNode arrNode = (ArrayNode)curr;
+                for (int j = 0; j < arrNode.size(); j++) {
+                    if (arrNode.get(j).get(uuidPropertyName).asText().equals(steps[i])) {
+                        steps[i] = String.valueOf(j);
+                        index = j;
+                    }
+                }
+            }
+            if (index == -1) {
+                return Optional.empty();
+            }
+            curr = curr.get(index);
+        }
+        return Optional.of(new EntityPropertyURI(
+                propertyURI,
+                "/" + String.join("/", steps)
+        ));
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/model/attestation/EntityPropertyURI.java
+++ b/java/registry/src/main/java/io/opensaber/registry/model/attestation/EntityPropertyURI.java
@@ -1,0 +1,30 @@
+package io.opensaber.registry.model.attestation;
+
+import com.fasterxml.jackson.core.JsonPointer;
+
+public class EntityPropertyURI {
+    String propertyURI;
+    JsonPointer jsonPointer;
+
+    private EntityPropertyURI() { }
+
+    public EntityPropertyURI(String propertyURI, String jsonPointer) {
+        this.jsonPointer = JsonPointer.compile(jsonPointer);
+        this.propertyURI = propertyURI;
+    }
+
+    public JsonPointer getJsonPointer() {
+        return jsonPointer;
+    }
+
+    public String getPropertyURI() {
+        return propertyURI;
+    }
+
+    public static EntityPropertyURI merge(EntityPropertyURI m1, String uuidPath, String jsonPath) {
+        EntityPropertyURI merged = new EntityPropertyURI();
+        merged.propertyURI = m1.propertyURI + uuidPath;
+        merged.jsonPointer = JsonPointer.compile(m1.jsonPointer.toString() + jsonPath);
+        return merged;
+    }
+}

--- a/java/registry/src/main/java/io/opensaber/registry/model/state/Action.java
+++ b/java/registry/src/main/java/io/opensaber/registry/model/state/Action.java
@@ -1,0 +1,8 @@
+package io.opensaber.registry.model.state;
+
+public enum Action {
+    RAISE_CLAIM,
+    REJECT_CLAIM,
+    GRANT_CLAIM,
+    SET_TO_DRAFT
+}

--- a/java/registry/src/main/java/io/opensaber/registry/service/RuleEngineService.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/RuleEngineService.java
@@ -3,8 +3,12 @@ package io.opensaber.registry.service;
 import io.opensaber.registry.model.state.StateContext;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.StatelessKieSession;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class RuleEngineService {
@@ -15,10 +19,13 @@ public class RuleEngineService {
         this.kieContainer = kieContainer;
     }
 
+    public void doTransition(List<StateContext> stateContexts) {
+        StatelessKieSession kieSession = kieContainer.newStatelessKieSession();
+        kieSession.execute(stateContexts);
+    }
+
     public void doTransition(StateContext stateContext) {
-        KieSession kieSession = kieContainer.newKieSession();
-        kieSession.insert(stateContext);
-        kieSession.fireAllRules();
-        kieSession.dispose();
+        StatelessKieSession kieSession = kieContainer.newStatelessKieSession();
+        kieSession.execute(stateContext);
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
@@ -2,6 +2,7 @@ package io.opensaber.registry.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opensaber.pojos.attestation.AttestationPolicy;
 import io.opensaber.registry.middleware.util.Constants;
 
 import java.util.*;
@@ -14,6 +15,7 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 
+import io.opensaber.registry.model.attestation.AttestationPath;
 import org.apache.commons.collections.map.HashedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,5 +130,11 @@ public class DefinitionsManager {
 
     public String getSubjectPath(String title) {
         return definitionMap.get(title).getOsSchemaConfiguration().getSubjectJsonPath();
+    }
+
+    public List<AttestationPolicy> getAttestationPolicy(String entityType) {
+        return new ArrayList<>(definitionMap.get(entityType)
+                .getOsSchemaConfiguration()
+                .getAttestationPolicies());
     }
 }

--- a/java/registry/src/main/resources/public/_schemas/Student.json
+++ b/java/registry/src/main/resources/public/_schemas/Student.json
@@ -62,7 +62,7 @@
     ],
     "attestationPolicies": [
       {
-        "property": "educationDetails",
+        "property": "educationDetails/[]",
         "paths": ["$.educationDetails[?(@.osid == 'PROPERTY_ID')]['institute', 'program', 'graduationYear', 'marks']", "$.identityDetails['fullName']"],
         "type": "MANUAL",
         "attestorEntity": "Teacher",

--- a/java/registry/src/main/resources/workflow/statetransitions.drl
+++ b/java/registry/src/main/resources/workflow/statetransitions.drl
@@ -1,37 +1,32 @@
 import io.opensaber.registry.model.state.StateContext;
 import io.opensaber.registry.model.state.States;
 
-rule "Attestor granted the claim"
+rule "Set state as draft if there is a change"
     when
-        stateDefinition : StateContext(requestBodyHas("action") && getRequestBodyVal("action") == "GRANTED");
+        stateDefinition:StateContext(isModified() && !isAttestationRequested());
+    then
+        stateDefinition.setState(States.DRAFT);
+end
+
+rule "Send for attestation and Set state as attestation requested"
+    when
+        stateDefinition:StateContext(isAttestationRequested());
+    then
+        stateDefinition.setState(States.ATTESTATION_REQUESTED);
+        stateDefinition.setClaimId();
+end
+
+rule "Set state as Published when Claim is approved"
+    when
+        stateDefinition:StateContext(isClaimApproved());
     then
         stateDefinition.setState(States.PUBLISHED);
 end
 
-rule "Attestor rejected the claim"
+rule "Set state as Rejected when Claim is rejected"
     when
-        stateDefinition : StateContext(requestBodyHas("action") && getRequestBodyVal("action") == "DENIED");
+        stateDefinition:StateContext(isClaimRejected());
     then
         stateDefinition.setState(States.REJECTED);
-end
-
-rule "Set starting state as draft"
-    when
-        stateDefinition:StateContext(existingNode == null);
-    then
-        stateDefinition.setState(States.DRAFT);
-end
-
-rule "Set state as draft if there is a change"
-    when
-        stateDefinition:StateContext(existingNode != null && isAttributesChanged());
-    then
-        stateDefinition.setState(States.DRAFT);
-end
-
-rule "Set state as attestation requested"
-    when
-        stateDefinition:StateContext(existingNode != null && isAttestationRequested());
-    then
-        stateDefinition.setState(States.ATTESTATION_REQUESTED);
+        stateDefinition.setRejectionMessage();
 end

--- a/java/registry/src/test/java/io/opensaber/registry/model/attestation/AttestationPathTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/model/attestation/AttestationPathTest.java
@@ -1,0 +1,77 @@
+package io.opensaber.registry.model.attestation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class AttestationPathTest {
+
+    private static final ObjectMapper m = new ObjectMapper();
+    private JsonNode node;
+    private static final String UUID_PROP = "osid";
+
+    private Set<String> convertToJsonPaths(Set<EntityPropertyURI> pointers) {
+        return pointers.stream().map(EntityPropertyURI::getPropertyURI).collect(Collectors.toSet());
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        node = m.readTree(new File("src/test/resources/attestationPathTest/example.json"));
+    }
+
+    @Test
+    public void testGetPointers_nestedArray() throws Exception {
+        List<String> expectedUUIDPaths = Arrays.asList(
+                "/education/1-324a-123/courses/0/0",
+                "/education/1-324a-123/courses/0/1",
+                "/education/1-324a-123/courses/0/2",
+                "/education/1-324a-123/courses/1/0",
+                "/education/1-324a-123/courses/1/1",
+                "/education/1-324a-123/courses/1/2",
+                "/education/1-324a-123/courses/2/0",
+                "/education/1-324a-123/courses/2/1",
+                "/education/1-324a-123/courses/3/0",
+                "/education/1-324a-121/courses/0/0",
+                "/education/1-324a-121/courses/0/1",
+                "/education/1-324a-121/courses/1/0",
+                "/education/1-324a-121/courses/1/1",
+                "/education/1-324a-121/courses/2/0",
+                "/education/1-324a-121/courses/3/0"
+        );
+
+        Set<EntityPropertyURI> pointers = new AttestationPath("education/[]/courses/[]/[]").getEntityPropertyURIs(node, UUID_PROP);
+        assertTrue(convertToJsonPaths(pointers).containsAll(expectedUUIDPaths));
+    }
+    @Test
+    public void testGetPointers_fieldPath() throws Exception {
+        Set<EntityPropertyURI> pointers = new AttestationPath("education").getEntityPropertyURIs(node, UUID_PROP);
+        assertEquals(1, pointers.size());
+        assertTrue(convertToJsonPaths(pointers).contains("/education"));
+    }
+
+    @Test
+    public void testGetPointers_fieldInsideArray() throws Exception {
+        Set<EntityPropertyURI> pointers = new AttestationPath("education/[]/courses").getEntityPropertyURIs(node, UUID_PROP);
+        assertEquals(2, pointers.size());
+    }
+
+    @Test
+    public void testGetPointers_twoArrayAncestors() throws Exception {
+        List<String> expectedUUIDPaths = Arrays.asList(
+                "/education/1-324a-123/awards/1-awd-001",
+                "/education/1-324a-123/awards/1-awd-002",
+                "/education/1-324a-121/awards/1-awd-0021"
+        );
+
+        Set<EntityPropertyURI> pointers = new AttestationPath("education/[]/awards/[]").getEntityPropertyURIs(node, UUID_PROP);
+        assertTrue(convertToJsonPaths(pointers).containsAll(expectedUUIDPaths));
+    }
+}

--- a/java/registry/src/test/resources/StateContext/existingNode.json
+++ b/java/registry/src/test/resources/StateContext/existingNode.json
@@ -1,0 +1,25 @@
+{
+  "Student": {
+    "identityDetails": {
+      "osid": "1-ert23-no123",
+      "name": "Loki Laufeyson",
+      "gender": "Other",
+      "dob": "965-12-17",
+      "nationalIdentity": "did:aadhaar:10021141"
+    },
+    "contactDetails": {
+      "osid": "1-eit23-85123",
+      "email": "loki@iou.com",
+      "mobile": "0000000001"
+    },
+    "educationDetails": [
+      {
+        "osid": "1-ewt23-no113",
+        "institute": "Asgard Institute of Magic",
+        "title": "B.Mg",
+        "from": "972",
+        "to": "975"
+      }
+    ]
+  }
+}

--- a/java/registry/src/test/resources/StateContext/updatedNode.json
+++ b/java/registry/src/test/resources/StateContext/updatedNode.json
@@ -1,0 +1,51 @@
+{
+  "Student": {
+    "identityDetails": {
+      "osid": "1-ert23-no123",
+      "name": "Loki Laufeyson",
+      "gender": "Other",
+      "dob": "965-12-17",
+      "nationalIdentity": "did:pan:10023441"
+    },
+    "contactDetails": {
+      "osid": "1-eit23-85123",
+      "email": "loki@iou.com",
+      "mobile": "0000000001"
+    },
+    "educationDetails": [
+      {
+        "osid": "1-ewt87-no007",
+        "institute": "Asgard Institute of Magic",
+        "title": "M.Mg",
+        "from": "975",
+        "to": "977"
+      },
+      {
+        "osid": "1-ewt23-no113",
+        "institute": "Asgard Institute of Magic",
+        "title": "B.Mg",
+        "from": "972",
+        "to": "975",
+        "courses": [
+          [
+            "CL101",
+            "LK101",
+            "TY101"
+          ],
+          [
+            "CL201",
+            "LK301",
+            "TY501"
+          ]
+        ],
+        "awards": [
+          {
+            "osid": "1-awd23-no113",
+            "title": "Trickster of the year",
+            "year": "973"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/java/registry/src/test/resources/attestationPathTest/example.json
+++ b/java/registry/src/test/resources/attestationPathTest/example.json
@@ -1,0 +1,44 @@
+{
+  "name": "Er P",
+  "education": [
+    {
+      "osid": "1-324a-123",
+      "institute": "X",
+      "courses": [
+        ["A1", "A2", "A3"],
+        ["B1", "B2", "B3"],
+        ["C1", "C2"],
+        ["D1"]
+      ],
+      "awards": [
+        {
+          "osid": "1-awd-001",
+          "name": "Hon. Tyu",
+          "reason": "vfkui uygi"
+        },
+        {
+          "osid": "1-awd-002",
+          "name": "Hon. Tyu",
+          "reason": "vfkui uygi"
+        }
+      ]
+    },
+    {
+      "osid": "1-324a-121",
+      "institute": "Y",
+      "courses": [
+        ["A1", "A2"],
+        ["B1", "B2"],
+        ["C1"],
+        ["D1"]
+      ],
+      "awards": [
+        {
+          "osid": "1-awd-0021",
+          "name": "Hon. Tyu",
+          "reason": "vfkui uygi"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Introduced propertyURI to handle generic scenarios
  *  according to current schema the URI for an education element will be `educationDetails/<osid>`
* Now StateContext requires `existingSubNode (empty incase of new additions)`, `updatedSubNode (empty incase of attest and raise claim operations)`, `attestationPolicy` relevant to the subNode, `metaDataNode` and `jsonPointer to the subEntity from metaDataNode` which will be used to write metadata
* Changed ` POST  /entityName/entityId/propertyName` to handle any type of nodes
* Changed `PUT  /entityName/entityId/propertyName` and ` POST  /entityName/entityId/propertyName` apis to merge objects first and send for update to registry service. So need to update ES separately. (removed `updateEntityInEs`)
